### PR TITLE
#27 Add prescan phase for short-circuit boolean expression decompilation

### DIFF
--- a/pycrefine.py
+++ b/pycrefine.py
@@ -963,15 +963,11 @@ class DecompilerGeneric(DecompilerBase):
                 op = jinstr.opname
                 is_success_type = ("IF_TRUE" in op)
                 
-                # Logic: is_or_jump is True if jump targets body (Success) or 
-                # a later part of the chain that allows bypassing the alternative.
                 if t == body_target:
                     is_or_jump = True
                 elif t == end_target:
                     is_or_jump = False
                 else:
-                    # Intra-group jump. If it's a success-type jump to a later offset, 
-                    # it indicates an OR short-circuit.
                     is_or_jump = is_success_type
 
                 if "IF_NONE" in op and "NOT" not in op:
@@ -1083,15 +1079,6 @@ class DecompilerGeneric(DecompilerBase):
             or "IF_NOT_NONE" in opname
         )
 
-    def _is_compound_or_jump(self, opname: str) -> bool:
-        """
-        Determine whether an opcode name represents a short-circuit OR-style conditional jump.
-        
-        Returns:
-            bool: `True` if `opname` contains "IF_TRUE", or contains "IF_NONE" but does not contain "AND" or "NOT"; `False` otherwise.
-        """
-        return "IF_TRUE" in opname or ("IF_NONE" in opname and "AND" not in opname and "NOT" not in opname)
-
     def _eval_cond_expr(self, instrs: list) -> str:
         """
         Constructs a boolean expression string from a sequence of bytecode instructions.
@@ -1168,10 +1155,14 @@ class DecompilerGeneric(DecompilerBase):
             elif op == "BINARY_OP":
                 if len(mini_stack) >= 2:
                     right, left = mini_stack.pop(), mini_stack.pop()
-                    op_map = {0:"+",1:"&",2:"//",3:"<<",4:"@",5:"*",
-                              6:"%",7:"|",8:"**",9:">>",10:"-",11:"/",12:"^"}
+                    op_map = {0:"+", 1:"&", 2:"//", 3:"<<", 4:"@", 5:"*",
+                              6:"%", 7:"|", 8:"**", 9:">>", 10:"-", 11:"/", 12:"^",
+                              26: "[]"}
                     sym = op_map.get(int(ins.arg) if ins.arg is not None else -1, "?")
-                    mini_stack.append(f"({left} {sym} {right})")
+                    if sym == "[]":
+                        mini_stack.append(f"{left}[{right}]")
+                    else:
+                        mini_stack.append(f"({left} {sym} {right})")
             elif op in ("IS_OP",):
                 if len(mini_stack) >= 2:
                     right, left = mini_stack.pop(), mini_stack.pop()
@@ -2163,12 +2154,7 @@ class DecompilerGeneric(DecompilerBase):
                         self.blocks.append((end_offset, "while"))
                         self._while_true_ends.add(end_offset)
 
-        elif (
-            "POP_JUMP_IF_FALSE" in opname
-            or "POP_JUMP_IF_TRUE" in opname
-            or "POP_JUMP_IF_NONE" in opname
-            or "POP_JUMP_IF_NOT_NONE" in opname
-        ):
+        elif self._is_compound_cjump(opname):
             # ── Ternary expression detection ──────────────────────────────
             # If _prescan_ternaries identified this jump as a ternary, evaluate
             # both branches speculatively and push the ternary expression onto

--- a/tests/test_pycrefine.py
+++ b/tests/test_pycrefine.py
@@ -2869,6 +2869,33 @@ class TestCompoundConditions(unittest.TestCase):
         header_count = sum(1 for line in out.splitlines() if line.lstrip().startswith("if "))
         self.assertEqual(header_count, 2)
 
+    def test_compound_with_function_calls(self):
+        """
+        Verify that function calls with parentheses do not disrupt precedence tracking.
+        """
+        src = "def f(x, y):\n    if len(x) > 0 and (y is None or x[0] == 1):\n        return True\n    return False\n"
+        out = decompile(src)
+        # Verify that len(x) is NOT wrapped, but (y is None or x[0] == 1) IS wrapped correctly.
+        self.assertTrue("len(x) > 0 and (y is None or x[0] == 1)" in out)
+        header_count = sum(1 for line in out.splitlines() if line.lstrip().startswith("if "))
+        self.assertEqual(header_count, 1)
+
+    def test_compound_flat_shared_target(self):
+        """
+        Verify that contiguous flat operands with shared jump targets (common in None checks)
+        do not trigger RecursionError and are grouped correctly.
+        """
+        src = (
+            "def test(a, b, c, d, e):\n"
+            "    if a is None and b is None and c is None and d is None and e is None:\n"
+            "        return True\n"
+            "    return False\n"
+        )
+        out = decompile(src)
+        assert_contains(out, "if a is None and b is None and c is None and d is None and e is None:")
+        header_count = sum(1 for line in out.splitlines() if line.lstrip().startswith("if "))
+        self.assertEqual(header_count, 1)
+
 
 # ---------------------------------------------------------------------------
 # Entry point


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decompiler now recognizes and reconstructs compound boolean chains (and/or, including is None/is not None, indexing/function-call clauses), emitting clearer combined if/while headers and improved merged-header output.
  * Ternary/conditional expressions handle subscription-style formatting more accurately.

* **Bug Fixes**
  * Removed extra trailing newline at end-of-file in output.

* **Tests**
  * Added end-to-end tests for compound conditions, short-circuiting, precedence, indexing/calls, and a nested-if regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->