### PR TITLE
#65 Refine while-loop and break-in-try bytecode decompilation

### DIFF
--- a/pycrefine.py
+++ b/pycrefine.py
@@ -2009,10 +2009,7 @@ class DecompilerGeneric(DecompilerBase):
                     ):
                         dup_start = ins.offset + 2
 
-            # Register entire dup-condition region [dup_start .. JUMP_BACKWARD]
-            for ins in self.instructions:
-                if dup_start <= ins.offset <= jb.offset:
-                    self._while_body_offsets.add(ins.offset)
+            # (moved into guard_offset >= 0 check below to avoid suppressing for-loop inner nodes)
 
             # The loop guard: POP_JUMP_IF_FALSE immediately before body_start
             # whose target is beyond JUMP_BACKWARD (the loop-exit path).
@@ -2076,6 +2073,11 @@ class DecompilerGeneric(DecompilerBase):
                     guard_offset = ins.offset
             if guard_offset >= 0:
                 self._while_header_targets[body_start] = guard_offset
+                # Register entire dup-condition region [dup_start .. JUMP_BACKWARD]
+                # We only do this if this is definitely a while-loop (not a for loop jump back)
+                for ins in self.instructions:
+                    if dup_start <= ins.offset <= jb.offset:
+                        self._while_body_offsets.add(ins.offset)
             else:
                 # while-True pattern: no conventional guard found, but the
                 # back-edge target is a known jump target (loop start).
@@ -5405,33 +5407,9 @@ class Decompiler39(DecompilerGeneric):
                             _fb = getattr(self, "_finally_body_suppress", set())
                             _fb.add(self.instructions[look].offset)   # POP_TOP
                             _fb.add(jmp.offset)                        # JUMP_ABSOLUTE(break)
-                            # Suppress all NOPs between the break JUMP_ABSOLUTE and
-                            # the natural-continue POP_BLOCK that follows.
-                            sup = look2 + 1
-                            while (sup < len(self.instructions)
-                                   and self.instructions[sup].opname in (
-                                       "RESUME", "NOP", "CACHE")):
-                                _fb.add(self.instructions[sup].offset)
-                                sup += 1
-                            # Suppress the natural-continue POP_BLOCK (if-false target)
-                            # and its JUMP_ABSOLUTE back-edge, so they don't cause:
-                            #   (a) a spurious _except_header_indents push, and
-                            #   (b) a retroactive 'if' → 'while' rewrite.
-                            if (sup < len(self.instructions)
-                                    and self.instructions[sup].opname == "POP_BLOCK"):
-                                _fb.add(self.instructions[sup].offset)  # natural POP_BLOCK
-                                sup += 1
-                                while (sup < len(self.instructions)
-                                       and self.instructions[sup].opname in (
-                                           "RESUME", "NOP", "CACHE")):
-                                    sup += 1
-                                if (sup < len(self.instructions)
-                                        and self.instructions[sup].opname == "JUMP_ABSOLUTE"):
-                                    _fb.add(self.instructions[sup].offset)  # natural JUMP_ABSOLUTE
                             self._finally_body_suppress = _fb
-                            # Return early: do NOT push to _except_header_indents.
-                            # The DUP_TOP handler (exception handler entry) will set up
-                            # the indent correctly via its own _except_header_indents logic.
+                            # Return early: do NOT pop the 'if' block.
+                            # The natural POP_BLOCK will follow and handle the try_body exit appropriately.
                             return
 
             if self.blocks and self.blocks[-1][1] in ("try_body", "exc_cleanup"):

--- a/pycrefine.py
+++ b/pycrefine.py
@@ -5477,6 +5477,7 @@ class Decompiler39(DecompilerGeneric):
                                         and self.instructions[sup].opname == "JUMP_ABSOLUTE"):
                                     _fb.add(self.instructions[sup].offset)
                                 self._finally_body_suppress = _fb
+                                return
 
                     # Python 3.9 for-loop break inside try: the break path is
                     # POP_BLOCK -> POP_TOP -> JUMP_ABSOLUTE(past FOR_ITER end).
@@ -5514,6 +5515,7 @@ class Decompiler39(DecompilerGeneric):
                                 _fb.add(nxt.offset)                    # POP_TOP
                                 _fb.add(jmp.offset)                    # JUMP_ABSOLUTE
                                 self._finally_body_suppress = _fb
+                                return
 
                 finally_target = self.blocks[-1][0]
                 _finally_ts = getattr(self, "_finally_targets", set())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -153,7 +153,7 @@ class TestComprehensions(unittest.TestCase):
             self.assertIn("yield (x * 2)", out)
             self.assertNotIn("append", out)
         else:
-            self.assertTrue("[x * 2 for x in items]" in out or "[(x * 2) for x in items]" in out)
+            self.assertTrue("[x * 2 for x in items if x > 0]" in out or "[(x * 2) for x in items if x > 0]" in out)
 
     def test_dict_comprehension_yield(self):
         src = "def h(items):\n    return {k: v for k, v in items}\n"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -265,6 +265,30 @@ class TestBreakInTryInsideWhile(unittest.TestCase):
         self.assertNotIn("e = None", out)
         self.assertNotIn("del e", out)
 
+class TestBreakInTryInsideFor(unittest.TestCase):
+    def test_for_try_if_break_correct_indentation(self):
+        src = "def f(items):\n    for i in items:\n        try:\n            if i > 0:\n                break\n        except Exception:\n            pass\n"
+        out = decompile(src)
+        lines = out.splitlines()
+        try_lines    = [ln for ln in lines if ln.lstrip() == "try:"]
+        except_lines = [ln for ln in lines if ln.lstrip().startswith("except Exception:")]
+        self.assertTrue(try_lines, "try: not found")
+        self.assertTrue(except_lines, "except Exception: not found")
+        
+        try_indent    = len(try_lines[0])    - len(try_lines[0].lstrip())
+        except_indent = len(except_lines[0]) - len(except_lines[0].lstrip())
+        self.assertEqual(
+            try_indent, except_indent,
+            f"'try:' at indent {try_indent} but 'except' at indent {except_indent}:\n{out}",
+        )
+
+    def test_no_false_while_in_try_break(self):
+        # Negative test: ensure the if/break pattern inside try isn't mistakenly wrapped
+        # as a `while` loop due to jump-backs.
+        src = "def f(items):\n    for i in items:\n        try:\n            if i > 0:\n                break\n        except Exception:\n            pass\n"
+        out = decompile(src)
+        # We expect a for loop and an if statement, but NOT a while statement.
+        self.assertNotIn("while i > 0:", out)
 
 class TestNestedTryInsideExcept(unittest.TestCase):
     def _run39_full(self, instructions):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -265,16 +265,50 @@ class TestBreakInTryInsideWhile(unittest.TestCase):
         self.assertNotIn("e = None", out)
         self.assertNotIn("del e", out)
 
+
+@unittest.skipIf(sys.version_info >= (3, 11), "Python 3.11+ uses zero-cost exception tables, no POP_BLOCK")
 class TestBreakInTryInsideFor(unittest.TestCase):
+    """Regression tests for break inside an if inside a try inside a for loop (Python 3.9).
+
+    The root bug: when POP_BLOCK fires with 'if' on top of the block stack and
+    'try_body' below it, the handler must return early after emitting 'break' and
+    suppressing the implementation-detail instructions.  Without the early return the
+    try_body block is popped prematurely, indent_level is decremented, and
+    _except_header_indents gets a ghost entry — producing a SyntaxError near the
+    'except' clause in the decompiled output.
+    """
+
+    # Shared source string used by multiple test methods (DRY).
+    _SRC_IF_BREAK = (
+        "def f(items):\n"
+        "    for i in items:\n"
+        "        try:\n"
+        "            if i > 0:\n"
+        "                break\n"
+        "        except Exception:\n"
+        "            pass\n"
+    )
+
+    _SRC_BARE_BREAK = (
+        "def f(items):\n"
+        "    for i in items:\n"
+        "        try:\n"
+        "            break\n"
+        "        except Exception:\n"
+        "            pass\n"
+    )
+
+    # ── positive indentation assertions ──────────────────────────────────────
+
     def test_for_try_if_break_correct_indentation(self):
-        src = "def f(items):\n    for i in items:\n        try:\n            if i > 0:\n                break\n        except Exception:\n            pass\n"
-        out = decompile(src)
+        """try: and except: must be at the same indent level."""
+        out = decompile(self._SRC_IF_BREAK)
         lines = out.splitlines()
         try_lines    = [ln for ln in lines if ln.lstrip() == "try:"]
         except_lines = [ln for ln in lines if ln.lstrip().startswith("except Exception:")]
-        self.assertTrue(try_lines, "try: not found")
+        self.assertTrue(try_lines,    "try: not found")
         self.assertTrue(except_lines, "except Exception: not found")
-        
+
         try_indent    = len(try_lines[0])    - len(try_lines[0].lstrip())
         except_indent = len(except_lines[0]) - len(except_lines[0].lstrip())
         self.assertEqual(
@@ -282,13 +316,68 @@ class TestBreakInTryInsideFor(unittest.TestCase):
             f"'try:' at indent {try_indent} but 'except' at indent {except_indent}:\n{out}",
         )
 
+    def test_for_try_bare_break_correct_indentation(self):
+        """break directly in try body (no enclosing if) must still align except correctly."""
+        out = decompile(self._SRC_BARE_BREAK)
+        lines = out.splitlines()
+        try_lines    = [ln for ln in lines if ln.lstrip() == "try:"]
+        except_lines = [ln for ln in lines if ln.lstrip().startswith("except Exception:")]
+        self.assertTrue(try_lines,    f"try: not found:\n{out}")
+        self.assertTrue(except_lines, f"except Exception: not found:\n{out}")
+
+        try_indent    = len(try_lines[0])    - len(try_lines[0].lstrip())
+        except_indent = len(except_lines[0]) - len(except_lines[0].lstrip())
+        self.assertEqual(
+            try_indent, except_indent,
+            f"'try:' at indent {try_indent} but 'except' at indent {except_indent}:\n{out}",
+        )
+
+    # ── syntax validity guard (original bug was a SyntaxError) ───────────────
+
+    def test_if_break_output_is_valid_python(self):
+        """Decompiled output must parse without SyntaxError (direct regression guard)."""
+        import ast as _ast
+        out = decompile(self._SRC_IF_BREAK)
+        try:
+            _ast.parse(out)
+        except SyntaxError as exc:
+            self.fail(f"Decompiled output is not valid Python: {exc}\n{out}")
+
+    def test_bare_break_output_is_valid_python(self):
+        """Bare-break variant must also produce syntactically valid output."""
+        import ast as _ast
+        out = decompile(self._SRC_BARE_BREAK)
+        try:
+            _ast.parse(out)
+        except SyntaxError as exc:
+            self.fail(f"Decompiled output is not valid Python: {exc}\n{out}")
+
+    # ── negative assertions ───────────────────────────────────────────────────
+
     def test_no_false_while_in_try_break(self):
-        # Negative test: ensure the if/break pattern inside try isn't mistakenly wrapped
-        # as a `while` loop due to jump-backs.
-        src = "def f(items):\n    for i in items:\n        try:\n            if i > 0:\n                break\n        except Exception:\n            pass\n"
-        out = decompile(src)
-        # We expect a for loop and an if statement, but NOT a while statement.
-        self.assertNotIn("while i > 0:", out)
+        """The if/break pattern inside try must not be misread as a while loop.
+
+        Negative: no 'while' keyword of any form.
+        Positive: the 'if' keyword must be present (prevents silent pass if the
+        decompiler emits a parenthesised variant like 'while (i > 0):').
+        """
+        out = decompile(self._SRC_IF_BREAK)
+        # No while loop should appear anywhere in the output.
+        self.assertNotIn("while", out, f"Spurious 'while' keyword in output:\n{out}")
+        # The conditional must be emitted as 'if', not dropped.
+        self.assertIn("if i > 0:", out, f"'if i > 0:' not found in output:\n{out}")
+
+    def test_break_is_emitted(self):
+        """The 'break' keyword must appear in the output."""
+        out = decompile(self._SRC_IF_BREAK)
+        self.assertIn("break", out, f"'break' not found:\n{out}")
+
+    def test_bare_break_is_emitted(self):
+        """'break' must appear in the bare-break variant too."""
+        out = decompile(self._SRC_BARE_BREAK)
+        self.assertIn("break", out, f"'break' not found:\n{out}")
+
+
 
 class TestNestedTryInsideExcept(unittest.TestCase):
     def _run39_full(self, instructions):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,7 @@
 import sys
 import unittest
+import re
+import ast
 
 from .test_helpers import _run39_full_impl, assert_contains, decompile
 
@@ -334,23 +336,21 @@ class TestBreakInTryInsideFor(unittest.TestCase):
 
     # ── syntax validity guard (original bug was a SyntaxError) ───────────────
 
-    def test_if_break_output_is_valid_python(self):
-        """Decompiled output must parse without SyntaxError (direct regression guard)."""
-        import ast as _ast
-        out = decompile(self._SRC_IF_BREAK)
+    def _assert_decompiled_valid(self, source):
+        """Helper to ensure decompiled source parses without SyntaxError."""
+        out = decompile(source)
         try:
-            _ast.parse(out)
+            ast.parse(out)
         except SyntaxError as exc:
             self.fail(f"Decompiled output is not valid Python: {exc}\n{out}")
 
+    def test_if_break_output_is_valid_python(self):
+        """Decompiled output must parse without SyntaxError (direct regression guard)."""
+        self._assert_decompiled_valid(self._SRC_IF_BREAK)
+
     def test_bare_break_output_is_valid_python(self):
         """Bare-break variant must also produce syntactically valid output."""
-        import ast as _ast
-        out = decompile(self._SRC_BARE_BREAK)
-        try:
-            _ast.parse(out)
-        except SyntaxError as exc:
-            self.fail(f"Decompiled output is not valid Python: {exc}\n{out}")
+        self._assert_decompiled_valid(self._SRC_BARE_BREAK)
 
     # ── negative assertions ───────────────────────────────────────────────────
 
@@ -363,7 +363,7 @@ class TestBreakInTryInsideFor(unittest.TestCase):
         """
         out = decompile(self._SRC_IF_BREAK)
         # No while loop should appear anywhere in the output.
-        self.assertNotIn("while", out, f"Spurious 'while' keyword in output:\n{out}")
+        self.assertIsNone(re.search(r'\bwhile\b', out), msg=f"Spurious 'while' keyword in output:\n{out}")
         # The conditional must be emitted as 'if', not dropped.
         self.assertIn("if i > 0:", out, f"'if i > 0:' not found in output:\n{out}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decompilation accuracy for break statements inside try-except blocks nested within for loops.
  * Enhanced list comprehension decompilation to correctly preserve filter clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->